### PR TITLE
install libdbd-sqlite3-perl on Ubuntu

### DIFF
--- a/data/Ubuntu.yaml
+++ b/data/Ubuntu.yaml
@@ -6,4 +6,5 @@ borg::restore_dependencies:
   - cpanminus
   - make
   - gcc
+  - libdbd-sqlite3-perl
 borg::install_restore_script: true


### PR DESCRIPTION
Ubuntu fails sometimes to build DBI::Sqlite because of a gcc bug. As a
workaround, we install the package via apt