### PR TITLE
Don't set `type=oneshot` for backup unit

### DIFF
--- a/templates/borg-backup.service.epp
+++ b/templates/borg-backup.service.epp
@@ -8,7 +8,6 @@
 Description=Create borg backups
 
 [Service]
-Type=oneshot
 ExecStart=/usr/local/bin/borg-backup
 <% if $create_prometheus_metrics { -%>
 ExecStartPost=/usr/local/bin/borg_exporter


### PR DESCRIPTION
This will block your shell until the backup is finished if you start the
unit in an interactive shell. By removing this, systemd will default to
`type=simple`.