### PR TITLE
fix wrong conditions in unit file

### DIFF
--- a/templates/borg-backup.service.epp
+++ b/templates/borg-backup.service.epp
@@ -11,10 +11,10 @@ Description=Create borg backups
 ExecStart=/usr/local/bin/borg-backup
 <% if $create_prometheus_metrics { -%>
 ExecStartPost=/usr/local/bin/borg_exporter
+<% } -%>
 <% if ($use_upstream_reporter == true) { -%>
 ExecStartPost=/usr/bin/cp /var/lib/node_exporter/textfile_collector/backup.prom /var/lib/prometheus-dropzone/
 <% } -%>
 <% if ($update_borg_restore_db_after_backuprun == true) { -%>
 ExecStartPost=<%= $restore_script_path %> --update-cache --debug
-<% } -%>
 <% } -%>


### PR DESCRIPTION
We have a few conditions in the systemd service file for our borg job.
They should be handled one after another. Instead, two were within the
first one. This resulted in a broken config and is now fixed.