### PR TITLE
#16: execute opt-deps only if they are present

### DIFF
--- a/templates/borg-backup.sh.epp
+++ b/templates/borg-backup.sh.epp
@@ -110,12 +110,27 @@ pre_backup() {
   # save some data that's useful for restores
   local backupDataDir=/root/backup-data/
   mkdir -p "$backupDataDir"
-  fdisk -l > "$backupDataDir/fdisk"
-  vgdisplay > "$backupDataDir/vgdisplay"
-  pvdisplay > "$backupDataDir/pvdisplay"
-  lvdisplay > "$backupDataDir/lvdisplay"
-  df -a > "$backupDataDir/df"
-  findmnt -l > "$backupDataDir/findmnt"
+  if [ $(command -v fdisk) ]; then
+    fdisk -l > "$backupDataDir/fdisk"
+  fi
+  if [ $(command -v vgdisplay) ]; then
+    vgdisplay > "$backupDataDir/vgdisplay"
+  fi
+  if [ $(command -v pvdisplay) ]; then
+    pvdisplay > "$backupDataDir/pvdisplay"
+  fi
+  if [ $(command -v lvdisplay) ]; then
+    lvdisplay > "$backupDataDir/lvdisplay"
+  fi
+  if [ $(command -v df) ]; then
+    df -a > "$backupDataDir/df"
+  fi
+  if [ $(command -v findmnt) ]; then
+    findmnt -l > "$backupDataDir/findmnt"
+  fi
+  if [ $(command -v mdadm) ]; then
+    mdadm --detail --scan > "$backupDataDir/mdadm"
+  fi
 
   # If you wish to use snapshots, create them here
 


### PR DESCRIPTION
We have a bunch of optional dependencies that we execute to get more
information. We should only call them if they are actually in our path.
In addition, we now save the information from `mdadm`