### PR TITLE
vgcfgbackup: add support for multiple VGs

### DIFF
--- a/templates/borg-backup.sh.epp
+++ b/templates/borg-backup.sh.epp
@@ -133,7 +133,7 @@ pre_backup() {
     mdadm --detail --scan > "$backupDataDir/mdadm"
   fi
   if [ $(command -v vgcfgbackup) ]; then
-    vgcfgbackup --file "$backupDataDir/vgcfgbackup"
+    vgcfgbackup --file "$backupDataDir/vgcfgbackup_%s"
   fi
 
   # If you wish to use snapshots, create them here


### PR DESCRIPTION
vgcfgbackup won't backup multiple VGs into a single file. To make it
work with a single path, we need to add `%s` to the filename. This will
be replaced with the name of the volumne group.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
