### PR TITLE
allow ssh port configuration

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -119,6 +119,12 @@ Data type: `String[1]`
 
 The path on the remote server where the backups should be written to.
 
+##### `manage_repository`
+
+Data type: `Boolean`
+
+A Boolean that enables/disables repository management. Only true on Ubuntu 16.04 at the moment
+
 ##### `exclude_pattern`
 
 Data type: `Array[String[1]]`
@@ -172,6 +178,14 @@ Data type: `String[1]`
 The ssh username to connect to the remote borg service.
 
 Default value: $facts['hostname']
+
+##### `ssh_port`
+
+Data type: `Stdlib::Port`
+
+SSH port for the remote server (default: 22). Will be written into the local ssh client configuration file.
+
+Default value: 22
 
 ## Defined types
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -48,6 +48,7 @@ class borg::config {
     home     => '/root',
     user     => 'root',
   }
+
   # /root/.ssh/config entry for the backup server
   ssh::client::config::user{'root':
     ensure        => present,
@@ -57,6 +58,7 @@ class borg::config {
         'User'         => $borg::username,
         'IdentityFile' => '~/.ssh/id_ed25519_borg',
         'Hostname'     => $borg::backupserver,
+        'Port'         => $borg::ssh_port,
       },
     },
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -69,6 +69,9 @@
 # @param username
 #   The ssh username to connect to the remote borg service.
 #
+# @param ssh_port
+#   SSH port for the remote server (default: 22). Will be written into the local ssh client configuration file.
+#
 class borg (
   Variant[String[1],Array[String[1]]] $package_name,
   Boolean $create_prometheus_metrics,
@@ -93,6 +96,7 @@ class borg (
   Array[Stdlib::Absolutepath] $additional_excludes = [],
   Array[Stdlib::Absolutepath] $additional_includes = [],
   String[1] $username                              = $facts['hostname'],
+  Stdlib::Port $ssh_port                           = 22,
 ) {
 
   contain borg::install


### PR DESCRIPTION
#### Pull Request (PR) description
Add ssh_port parameter so we can configure non-default ssh ports to be put into the ssh client config.

#### This Pull Request (PR) fixes the following issues
Fixes #36 