### PR TITLE
centos: install missing dep perl-Test-MockObject

### DIFF
--- a/data/RedHat.yaml
+++ b/data/RedHat.yaml
@@ -7,3 +7,4 @@ borg::restore_dependencies:
   - perl-local-lib
   - perl-Test-Simple
   - gcc
+  - perl-Test-MockObject


### PR DESCRIPTION
The dependency perl-Test-MockObject is now required for the restore
script.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
