### PR TITLE
BorgRestore: Increase exec timeout to 10->20min

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -15,10 +15,6 @@ _Private Classes_
 * `borg::install`: This class handles the installation. Avoid modifying private classes.
 * `borg::service`: 
 
-**Defined types**
-
-* [`borg::ssh_keygen`](#borgssh_keygen): Define: ssh_keygen this is based on https://github.com/maestrodev/puppet-ssh_keygen/blob/master/manifests/init.pp
-
 ## Classes
 
 ### borg
@@ -177,7 +173,7 @@ Data type: `String[1]`
 
 The ssh username to connect to the remote borg service.
 
-Default value: $facts['hostname']
+Default value: $facts['networking']['hostname']
 
 ##### `ssh_port`
 
@@ -186,71 +182,4 @@ Data type: `Stdlib::Port`
 SSH port for the remote server (default: 22). Will be written into the local ssh client configuration file.
 
 Default value: 22
-
-## Defined types
-
-### borg::ssh_keygen
-
-Define: ssh_keygen
-this is based on https://github.com/maestrodev/puppet-ssh_keygen/blob/master/manifests/init.pp
-
-#### Parameters
-
-The following parameters are available in the `borg::ssh_keygen` defined type.
-
-##### `user`
-
-Data type: `Any`
-
-The user that will own they key
-
-Default value: `undef`
-
-##### `type`
-
-Data type: `Any`
-
-the openssh key type
-
-Default value: `undef`
-
-##### `bits`
-
-Data type: `Any`
-
-The key length
-
-Default value: `undef`
-
-##### `home`
-
-Data type: `Any`
-
-The homedir where we will store the key
-
-Default value: `undef`
-
-##### `filename`
-
-Data type: `Any`
-
-The filename for the new key
-
-Default value: `undef`
-
-##### `comment`
-
-Data type: `Any`
-
-Comments that should be added to the key
-
-Default value: `undef`
-
-##### `options`
-
-Data type: `Any`
-
-Additional ssh-keygen paramters and options
-
-Default value: `undef`
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -35,7 +35,7 @@ class borg::install {
       creates     => "${venv_directory}/bin/borg-restore.pl",
       path        => "${$venv_directory}/bin::/usr/sbin:/usr/bin:/sbin:/bin",
       environment => ["PERL_MB_OPT='--install_base ${venv_directory}'", "PERL_MM_OPT='INSTALL_BASE=${venv_directory}'", "PERL5LIB='${venv_directory}/lib/perl5'", "PERL_LOCAL_LIB_ROOT=${venv_directory}", 'HOME=/root'],
-      timeout     => 600,
+      timeout     => 1200,
       cwd         => '/root',
       require     => Package[$borg::package_name],
     }


### PR DESCRIPTION
The exec resource installs some perl packages. Each perl package has a
testsuite that's executed as well. Due to enhancements there are now way
more tests and the installation might take longer.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
