### PR TITLE
Backup EFI data as well

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -10,6 +10,8 @@ borg::excludes:
 borg::includes:
   - '/'
   - '/boot'
+  - '/boot/efi'
+  - '/boot/EFI'
   - '/var/log'
 borg::keep_yearly: 3
 borg::keep_monthly: 24


### PR DESCRIPTION
On an EFI installtion we might see /boot/efi as seperate partition. This
needs to be backuped as well.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
