### PR TITLE
Exec: Replace `onlyif` with `unless` logic

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -49,7 +49,7 @@ class borg::install {
     }
     -> exec { 'install_borg_restore':
       command     => "cpanm --local-lib-contained ${venv_directory} App::BorgRestore@${borg::borg_restore_version}",
-      onlyif      => "perl -T -I /opt/BorgRestore/lib/perl5/ -MApp::BorgRestore -E 'exit (\"\$App::BorgRestore::VERSION\" eq \"${borg::borg_restore_version}\")'",
+      unless      => "perl -T -I /opt/BorgRestore/lib/perl5/ -MApp::BorgRestore -E 'exit (\"\$App::BorgRestore::VERSION\" ne \"${borg::borg_restore_version}\")'",
       path        => "${$venv_directory}/bin:/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin",
       environment => ["PERL_MB_OPT='--install_base ${venv_directory}'", "PERL_MM_OPT='INSTALL_BASE=${venv_directory}'", "PERL5LIB='${venv_directory}/lib/perl5'", "PERL_LOCAL_LIB_ROOT=${venv_directory}", 'HOME=/root'],
       timeout     => 1200,

--- a/spec/acceptance/init_spec.rb
+++ b/spec/acceptance/init_spec.rb
@@ -20,6 +20,9 @@ describe 'borg' do
       it { is_expected.to be_enabled }
       it { is_expected.to be_running }
     end
+    describe command('borg-restore.pl --version') do
+      its(:stdout) { is_expected.to match(%r{^Version: 3.4.3$}) }
+    end
   end
   context 'with a backup server and default repositry setup' do
     let(:pp) do
@@ -59,6 +62,9 @@ describe 'borg' do
     describe service('borg-backup.timer') do
       it { is_expected.to be_enabled }
       it { is_expected.to be_running }
+    end
+    describe command('borg-restore.pl --version') do
+      its(:stdout) { is_expected.to match(%r{^Version: 3.4.3$}) }
     end
   end
 end


### PR DESCRIPTION
The old code will fail if `/opt/BorgRestore/lib/perl5/` does not yet
contain any perl libs. So while it was fine for upgrading existing
setups, it failed to install new ones properly