### PR TITLE
Drop Puppet 5 since its almost EOL

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -87,7 +87,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 5.5.8 < 7.0.0"
+      "version_requirement": ">= 6.1.0 < 7.0.0"
     }
   ]
 }


### PR DESCRIPTION
Puppet 5 is EOL in a few days. Based on that I assume it's safe to
already drop it. It also allows us to test the migration to GitHub Action.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
