### PR TITLE
Add support for multiple / variable backup times.

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -60,6 +60,7 @@ The following parameters are available in the `borg` class:
 * [`proxy_server`](#proxy_server)
 * [`manage_package`](#manage_package)
 * [`ssh_key_type`](#ssh_key_type)
+* [`backuptime`](#backuptime)
 
 ##### <a name="package_name"></a>`package_name`
 
@@ -296,4 +297,12 @@ Data type: `Enum['rsa', 'ed25519']`
 configure your most favourite ssh key type. This will be used to connect to the remote borg server.
 
 Default value: `'ed25519'`
+
+##### <a name="backuptime"></a>`backuptime`
+
+Data type: `Hash[String[1],String[1]]`
+
+Configure the name of each backupjob and the time of that job.
+
+Default value: `{ 'default' => '18:30:00' }`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -93,6 +93,9 @@
 # @param ssh_key_type
 #   configure your most favourite ssh key type. This will be used to connect to the remote borg server.
 #
+# @param backuptime
+#   Configure the name of each backupjob and the time of that job.
+#
 # @see https://metacpan.org/pod/App::BorgRestore
 #
 class borg (
@@ -127,6 +130,7 @@ class borg (
   Optional[String[1]] $proxy_server                        = undef,
   Boolean $manage_package                                  = true,
   Enum['rsa', 'ed25519'] $ssh_key_type                     = 'ed25519',
+  Hash[String[1],String[1]] $backuptime                    = { 'default' => '18:30:00' },
 ) {
   contain borg::install
   contain borg::config

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -17,9 +17,11 @@ class borg::service {
       ),
     }
     -> systemd::unit_file { 'borg-backup.timer':
-      content => epp("${module_name}/borg-backup.timer.epp"),
-      enable  => true,
-      active  => true,
+      content      => epp("${module_name}/borg-backup.timer.epp",
+        backuptime => $borg::backuptime
+      ),
+      enable       => true,
+      active       => true,
     }
   }
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -125,6 +125,39 @@ describe 'borg' do
 
         it { is_expected.to compile.with_all_deps }
       end
+
+      context 'fails without a valid backuptime present' do
+        let :params do
+          {
+            backupserver: 'localhost',
+            backuptime: ''
+          }
+        end
+
+        it { is_expected.not_to compile }
+      end
+
+      context 'with nondefault backuptime present' do
+        let :params do
+          {
+            backupserver: 'localhost',
+            backuptime:   { 'default' => '01:00:00' }
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+      end
+
+      context 'with multiple backuptimes present' do
+        let :params do
+          {
+            backupserver: 'localhost',
+            backuptime:   { '1 am' => '01:00:00', '2 am' => '02:00:00' }
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+      end
     end
   end
 end

--- a/templates/borg-backup.timer.epp
+++ b/templates/borg-backup.timer.epp
@@ -1,12 +1,16 @@
+<%- | Hash[String,String] $backuptime,
+| -%>
 # THIS FILE IS MANAGED BY PUPPET
 [Unit]
-Description=Daily Timer for borg-backup
+Description=Daily Timer(s) for borg-backup
 
 [Timer]
 # OnBootSec=10min
 # OnUnitActiveSec=1d
-# Daily at 8am
-OnCalendar=*-*-* 18:30:00
+<% $backuptime.each | $jobname, $time | { -%>
+# Daily named job "<%= $jobname %>" at <%= $time %>
+OnCalendar=*-*-* <%= $time %>
+<% } -%>
 Persistent=True
 
 [Install]


### PR DESCRIPTION
Fixes #91 
replaces #92 

This now looks as this:

```diff
--- /etc/systemd/system/borg-backup.timer       2021-07-12 13:35:20.895432545 +0200
+++ /tmp/puppet-file20210720-108100-1p92i82     2021-07-20 09:46:01.670324290 +0200
@@ -1,11 +1,11 @@
 # THIS FILE IS MANAGED BY PUPPET
 [Unit]
-Description=Daily Timer for borg-backup
+Description=Daily Timer(s) for borg-backup

 [Timer]
 # OnBootSec=10min
 # OnUnitActiveSec=1d
-# Daily at 8am 
+# Daily named job "default" at 18:30:00
 OnCalendar=*-*-* 18:30:00
 Persistent=True
```
