### PR TITLE
Surround mountpoints in configuration file with quotes, avoid whitespace prefix for exclude patterns

### DIFF
--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -197,6 +197,17 @@ describe 'borg' do
         it { is_expected.to contain_file('/etc/profile.d/borg.sh').with_content(%r{^export BORG_REPO=backup:/some/other/path$}) }
         it { is_expected.to contain_file('/usr/local/bin/borg-backup').with_content(%r{\s*borg_repo="backup:/some/other/path"$}) }
       end
+
+      context 'with additional excludes' do
+        let :params do
+          {
+            backupserver: 'localhost',
+            additional_excludes: ['/path with/spaces']
+          }
+        end
+
+        it { is_expected.to contain_file('/etc/backup-sh-conf.sh').with_content(%r{^"/path with/spaces"$}) }
+      end
     end
   end
 end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -208,6 +208,17 @@ describe 'borg' do
 
         it { is_expected.to contain_file('/etc/backup-sh-conf.sh').with_content(%r{^"/path with/spaces"$}) }
       end
+
+      context 'without exclude_pattern' do
+        let :params do
+          {
+            backupserver: 'localhost',
+            exclude_pattern: ['sh:/some/path/*']
+          }
+        end
+
+        it { is_expected.to contain_file('/usr/local/bin/borg-backup').with_content(%r{^sh:/some/path/\*$}) }
+      end
     end
   end
 end

--- a/templates/backup-sh-conf.sh.epp
+++ b/templates/backup-sh-conf.sh.epp
@@ -2,17 +2,17 @@
 
 excludeMountpoints=(
 <% $borg::excludes.each |$key| { -%>
-<%= $key %>
+"<%= $key %>"
 <% } -%>
 <% $borg::additional_excludes.each |$key| { -%>
-<%= $key %>
+"<%= $key %>"
 <% } -%>
 )
 includeMountpoints=(
 <% $borg::includes.each |$key| { -%>
-<%= $key %>
+"<%= $key %>"
 <% } -%>
 <% $borg::additional_includes.each |$key| { -%>
-<%= $key %>
+"<%= $key %>"
 <% } -%>
 )

--- a/templates/borg-backup.sh.epp
+++ b/templates/borg-backup.sh.epp
@@ -87,7 +87,7 @@ main() {
   # well as regex pattern. Refer to man borg for details.
   IFS='' read -r -d '' excludeList <<-EOF || true
 <% $borg::exclude_pattern.each |$key| { -%>
-  <%= $key %>
+<%= $key %>
 <% } -%>
 EOF
 


### PR DESCRIPTION
#### Pull Request (PR) description
##### Surround mountpoints in configuration file with quotes 
This allows mountpoints with spaces. Those would otherwise end up like this:
`backup-sh-conf.sh`
```
excludeMountpoints=(
/var/lib/Foo Bar
)
```

`exclude-list-borg`:
```
sh:/var/lib/Foo/*
sh:Bar/*
```

##### Make sure exclude patterns are not prefixed by whitespace
Otherwise they end up like this:
`exclude-list-borg`:
```
  sh:/root/.cache/*
```

While I guess this wouldn't break the above example, other patterns might not work like this.