### PR TITLE
Make sure /etc/borg contains the absolutebackupdestdir if it is set

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -78,6 +78,12 @@ class borg::install {
       mode    => '0755',
     }
   }
+
+  $backupdestdir = $borg::absolutebackupdestdir ? {
+    Undef   => "${borg::username}/${borg::backupdestdir}",
+    default => $borg::absolutebackupdestdir,
+  }
+
   # we're now switching to rh-perl524 from centos-sclo-rh (which comes from the foreman module?)
   if $borg::create_prometheus_metrics {
     if $borg::use_upstream_reporter {
@@ -110,17 +116,12 @@ class borg::install {
     file { '/etc/borg':
       ensure  => 'file',
       content => epp("${module_name}/borg.epp", {
-          'username'      => $borg::username,
-          'backupdestdir' => $borg::backupdestdir,
+          'backupdestdir' => $backupdestdir,
       }),
     }
   }
 
   # setup a profile to export the backup server/path. Otherwise the CLI tooles don't work
-  $backupdestdir = $borg::absolutebackupdestdir ? {
-    Undef   => "${borg::username}/${borg::backupdestdir}",
-    default => $borg::absolutebackupdestdir,
-  }
   file { '/etc/profile.d/borg.sh':
     ensure  => 'file',
     content => epp("${module_name}/borg.sh.epp", {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -183,6 +183,20 @@ describe 'borg' do
 
         it { is_expected.not_to contain_file('/usr/local/bin/borg-backup').with_content(%r{/^\s+borg prune/}) }
       end
+
+      context 'with absolute backup destination dir present' do
+        let :params do
+          {
+            backupserver: 'localhost',
+            create_prometheus_metrics: true,
+            absolutebackupdestdir: '/some/other/path'
+          }
+        end
+
+        it { is_expected.to contain_file('/etc/borg').with_content(%r{^REPOSITORY=backup:/some/other/path$}) }
+        it { is_expected.to contain_file('/etc/profile.d/borg.sh').with_content(%r{^export BORG_REPO=backup:/some/other/path$}) }
+        it { is_expected.to contain_file('/usr/local/bin/borg-backup').with_content(%r{\s*borg_repo="backup:/some/other/path"$}) }
+      end
     end
   end
 end

--- a/templates/borg.epp
+++ b/templates/borg.epp
@@ -1,7 +1,6 @@
-<%- | String[1] $username,
-      String[1] $backupdestdir
+<%- | String[1] $backupdestdir
 | -%>
 # THIS FILE IS MANAGED BY PUPPET
 BORG_PASSPHRASE=''
-REPOSITORY=backup:<%= $username %>/<%= $backupdestdir %>
+REPOSITORY=backup:<%= $backupdestdir %>
 COLLECTOR_DIR=/var/lib/prometheus-dropzone


### PR DESCRIPTION
If an `$absolutebackupdestdir` is provided we need to set it in the Prometheus Exporter config file instead of the `username/borg` default.