### PR TITLE
Implement support for older borg versions

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -6,6 +6,10 @@ class borg::config {
     Undef   => "${borg::username}/${borg::backupdestdir}",
     default => $borg::absolutebackupdestdir,
   }
+  $numeric = versioncmp(pick(fact('borgbackup.version'), '1.2.0'), '1.2.0') ? {
+    -1      => '--numeric-owner',
+    default => '--numeric-ids',
+  }
 
   # script to run the backup
   file { '/usr/local/bin/borg-backup':
@@ -24,6 +28,7 @@ class borg::config {
         'backupdatadir'      => $borg::backupdatadir,
         'pre_backup_script'  => $borg::pre_backup_script,
         'post_backup_script' => $borg::post_backup_script,
+        'numeric'            => $numeric,
     }),
     mode    => '0755',
     owner   => 'root',

--- a/templates/borg-backup.sh.epp
+++ b/templates/borg-backup.sh.epp
@@ -10,6 +10,7 @@
       Stdlib::Absolutepath $backupdatadir,
       Optional[String[1]] $pre_backup_script,
       Optional[String[1]] $post_backup_script,
+      Enum['--numeric-owner', '--numeric-ids'] $numeric,
 | -%>
 #!/bin/bash
 #
@@ -165,7 +166,7 @@ backup_borg() {
   local src=("$@")
   local -a options=(
     --verbose
-    --numeric-ids
+    <%= $numeric %>
     --compression "<%= $compression %>"
     --exclude-from "$TMPDIR/exclude-list-borg"
     )


### PR DESCRIPTION
`--numeric-ids` is only available since borgbackup 1.2.0 and newer.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
