### PR TITLE
Run backup create with set +e if pruning is enabled

### DIFF
--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -24,7 +24,7 @@ describe 'borg' do
 
         it { is_expected.to contain_file('/etc/borg') }
         it { is_expected.to contain_file('/etc/profile.d/borg.sh') }
-        it { is_expected.to contain_file('/usr/local/bin/borg-backup') }
+        it { is_expected.to contain_file('/usr/local/bin/borg-backup').with_content(%r{borg create.*" \|\| true}) }
         it { is_expected.to contain_file('/usr/local/bin/borg_exporter') }
         it { is_expected.to contain_file('/etc/borg-restore.cfg') }
         it { is_expected.to contain_class('borg::install') }
@@ -190,7 +190,7 @@ describe 'borg' do
           }
         end
 
-        it { is_expected.not_to contain_file('/usr/local/bin/borg-backup').with_content(%r{/^\s+borg prune/}) }
+        it { is_expected.to contain_file('/usr/local/bin/borg-backup').without_content(%r{/^\s+borg prune/}).without_content(%r{borg create.*" \|\| true}) }
       end
 
       context 'with absolute backup destination dir present' do

--- a/templates/borg-backup.sh.epp
+++ b/templates/borg-backup.sh.epp
@@ -180,7 +180,7 @@ backup_borg() {
   # Change the working directory in case the source paths are relative
   cd "<%= $working_directory %>"
 
-  borg create "${options[@]}" --stats --verbose "$dst::backup-$(date "+%Y%m%d-%H%M%S")" "${src[@]}"
+  borg create "${options[@]}" --stats --verbose "$dst::backup-$(date "+%Y%m%d-%H%M%S")" "${src[@]}"<% if $manage_prune { %> || true<% } %>
 <% if $manage_prune { -%>
   # keep all backups from the last <%= $keep_within %> days
   # keep at least one backup for each day for <%= $keep_daily %> days


### PR DESCRIPTION
In case a file changes during a backup, borg will log a warning like this:
```
Nov 07 18:30:05 webserver01 borg-backup[849693]: Creating archive at "backup:webserver01::backup-20231107-183001"
Nov 07 18:30:42 webserver01 borg-backup[849693]: /var/lib/postgresql/16/main/pg_wal/00000001000000010000004E: file changed while we backed it up
Nov 07 18:30:59 webserver01 borg-backup[849693]: /var/lib/fail2ban/fail2ban.sqlite3: file changed while we backed it up
```

It will finish the backup, but the exit code will be 1. Because of the set -e at the top, the script will exit. If manage_prune is true, a prune command is configured. It won't be executed when a file change during a backup.

We now add `|| true` to the backup create command.